### PR TITLE
bug: (segregation v1.1.1) this tries to address the building error of https://github.com/conda-forge/segregation-feedstock/pull/2 adding tqdm to the recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - numpy
     - scipy
     - libpysal
+    - tqdm
 
 test:
   imports:


### PR DESCRIPTION
I pulled all the automatic changes performed in https://github.com/conda-forge/segregation-feedstock/pull/2 and tweaked it adding `tqdm` in the recipe.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


<!--
This tries to address the building error of https://github.com/conda-forge/segregation-feedstock/pull/2 by adding `tqdm` in the recipe.
-->
